### PR TITLE
DEVOPS-3289 Updating newrelic_exporter.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine
+FROM python:3.11.4-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -3,37 +3,86 @@
 import time
 import requests
 import click
+import json
 
+from datetime import datetime, timedelta
 from prometheus_client import start_http_server
 from prometheus_client.core import GaugeMetricFamily, REGISTRY
 
 
 class NewrelicCollector(object):
   def __init__(self, apikey):
-    self.api_base_url = 'https://api.newrelic.com/'
+    self.graphql_base_url = "https://api.newrelic.com/graphql"
     self.api_key = apikey
 
   def collect(self):
-
-    headers = {'X-Api-Key': self.api_key  }
-    resp  = requests.get(self.api_base_url + 'v2/applications.json', headers=headers)
-
+    print("Collecting\n")
+    
     # The metrics we want to export.
-    metrics = {'response_time': GaugeMetricFamily('newrelic_application_response_time',' newrelic application response in sec', labels=["appname"]),
-    'throughput': GaugeMetricFamily('newrelic_application_throughput',' newrelic application throughput',labels=["appname"]),
-    'error_rate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error_rate', labels=["appname"]),
-    'apdex_target': GaugeMetricFamily('newrelic_application_apdex_target',' newrelic application apdex_target', labels=["appname"]),
-    'apdex_score': GaugeMetricFamily('newrelic_application_apdex_score',' newrelic application apdex_score', labels=["appname"]),
+    metrics = {
+        'apdexScore': GaugeMetricFamily('newrelic_application_apdex_score',' newrelic application apdex_score', labels=["appname"]),
+        'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error_rate', labels=["appname"]),
+        'hostCount': GaugeMetricFamily('newrelic_application_host_count','newrelic application host count', labels=["appname"]),
+        'instanceCount': GaugeMetricFamily('newrelic_applicaiton_instance_count','newrelic application instance count', labels=["appname"]),
+        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_application_non_web_response_time_average','newrelica applicationnon web response time average',labels=["appname"]),
+        'nonWebThroughput': GaugeMetricFamily('newrelic_application_non_web_throughput','newrelic applicationn on web throughput', labels=["appname"]),
+        'responseTimeAverage': GaugeMetricFamily('newrelic_application_response_time',' newrelic application response in sec', labels=["appname"]),
+        'throughput': GaugeMetricFamily('newrelic_application_throughput',' newrelic application throughput',labels=["appname"]),
+        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_web_response_time_average','newrelic_application web response time average', labels=["appname"]),
+        'webThroughput': GaugeMetricFamily('newrelic_application_web_throughput','newrelic application web throughput', labels=["appname"]),
     }
 
+    # Get all entity Guids
+    headers = {'API-Key': self.api_key}
+    resp  = requests.post(url=self.graphql_base_url, headers=headers, data="{actor {entitySearch(queryBuilder: {domain: APM}) {results {entities {... on ApmApplicationEntityOutline {name apmSummary {apdexScore errorRate hostCount instanceCount nonWebResponseTimeAverage nonWebThroughput responseTimeAverage throughput webResponseTimeAverage webThroughput}} guid}}}}}")
+    if resp.json().get("errors"):
+      print("Error getting newrelic entities:", resp.json())
+      return
+    
+    guidDict = {}
+    # saving guid and name in dictionary (guidDict)
+    for entity in resp.json().get("data").get("actor").get("entitySearch").get("results").get("entities"):
+      guidDict[entity["guid"]] = entity["name"]
+
+    # Pass the metrics to the prometheus by looping through entity
     for metric in metrics:
-      for app in resp.json().get('applications',{}):
-        if app.get('application_summary'):
+      for entity in  resp.json().get("data").get("actor").get("entitySearch").get("results").get("entities"):
+        if entity.get("apmSummary"):
           try:
-            metrics[metric].add_metric([app['name']], app['application_summary'][metric])
+            metrics[metric].add_metric([entity["name"]], entity.get("apmSummary")[metric])
           except KeyError:
             pass
       yield metrics[metric]
+
+    # We can pass only 25 Guids in one request, so dividing all guids in chunks of 25,
+    # and fetching deployments for those 25 guids
+    # Get list of deployment which happened in last 1 hour
+    t = datetime.today()-timedelta(hours=1)
+    deploymentArray = []
+    guids = list(guidDict.keys())
+    
+    chunk_size = 25
+    for i in range(0, len(guids), chunk_size):      
+      resp  = requests.post(url=self.graphql_base_url, headers=headers, data='{{actor {{entities(guids: {0}) {{deploymentSearch(filter: {{timeWindow: {{startTime: {1} }}}}) {{results {{version timestamp entityGuid}}}}}}}}}}'.format(json.dumps(guids[i:i+chunk_size]),round(t.timestamp()*1000)))
+      if resp.json().get("errors"):
+        print("Error getting newrelic deployments:", resp.json())
+        return
+
+      for entity in resp.json().get("data").get("actor").get("entities"):        
+        for deployments in entity.get("deploymentSearch").get("results"):          
+          deploymentArray.append({
+            "name": guidDict.get(deployments.get("entityGuid")),
+            "timestamp": deployments.get("timestamp"),
+            "version": deployments.get("version")
+          })
+        
+    print(deploymentArray)
+    # Expose deployment metric
+    deploymentMetric = GaugeMetricFamily('newrelic_application_deployment',' newrelic application deployment', labels=["appname", "version"])
+    for deployment in deploymentArray:
+      # Passing timestamp as seconds because prometheus client automatically converts timestamp to milliseconds
+      deploymentMetric.add_metric([deployment['name'], deployment['version']], 1, int(deployment['timestamp']/1000))
+    yield deploymentMetric
 
 @click.command()
 @click.option('--api-key', '-a', envvar='APIKEY', help='API key for newrelic', required=True)
@@ -42,7 +91,7 @@ def main(api_key):
   start_http_server(9126)
   while True: 
     time.sleep(1)
+    
 if __name__ == "__main__":
   main()
-
 

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -19,11 +19,11 @@ class NewrelicCollector(object):
     # The metrics we want to export.
     metrics = {
         # add the metrics
-        'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error_rate', labels=["appname"]),
-        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_response_time','newrelic_application web response time average', labels=["appname"]),
-        'webThroughput': GaugeMetricFamily('newrelic_application_throughput','newrelic application web throughput', labels=["appname"]),
-        'nonWebThroughput': GaugeMetricFamily('newrelic_nonweb_throughput','newrelic applicaiotn non web throughput', labels=["appname"]),
-        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_nonweb_response_time_average','newrelic nonweb response time average', labels=["appname"]),
+        'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error rate', labels=["appname"]),
+        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_response_time','newrelic application web response time average', labels=["appname"]),
+        'webThroughput': GaugeMetricFamily('newrelic_application_web_throughput','newrelic application web throughput', labels=["appname"]),
+        'nonWebThroughput': GaugeMetricFamily('newrelic_nonweb_throughput','newrelic application non web throughput', labels=["appname"]),
+        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_nonweb_response_time','newrelic application non web response time average', labels=["appname"]),
    }
 
     headers = {'API-Key': self.api_key}
@@ -82,8 +82,8 @@ class NewrelicCollector(object):
                                       results
                                       }}
                                   }}
-                              }}"""
-    resp  = requests.post(url=self.graphql_base_url, headers=headers, data=deploymentGraphQuery.format(timeInSeconds,self.account_number))
+                              }}""".format(timeInSeconds,self.account_number)
+    resp  = requests.post(url=self.graphql_base_url, headers=headers, data=deploymentGraphQuery)
     
     if resp.json().get("errors"):
         print("Error getting newrelic deployment response : ", resp.json())

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import json
 import time
 import requests
 import click
@@ -20,14 +19,37 @@ class NewrelicCollector(object):
     # The metrics we want to export.
     metrics = {
         # add the metrics
-        'apdexScore': GaugeMetricFamily('newrelic_application_apdex_score',' newrelic application apdex_score', labels=["appname"]),
         'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error_rate', labels=["appname"]),
         'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_response_time','newrelic_application web response time average', labels=["appname"]),
         'webThroughput': GaugeMetricFamily('newrelic_application_throughput','newrelic application web throughput', labels=["appname"]),
-    }
+        'nonWebThroughput': GaugeMetricFamily('newrelic_nonweb_throughput','newrelic applicaiotn non web throughput', labels=["appname"]),
+        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_nonweb_response_time_average','newrelic nonweb response time average', labels=["appname"]),
+   }
 
     headers = {'API-Key': self.api_key}
-    resp  = requests.post(url=self.graphql_base_url, headers=headers, data="{actor {entitySearch(queryBuilder: {domain: APM}) {results {entities { ... on ApmApplicationEntityOutline {name apmSummary { apdexScore errorRate webResponseTimeAverage webThroughput}}}}}}}")
+
+    graphQuery = """{
+                        actor {
+                          entitySearch(queryBuilder: {domain: APM}) {
+                            results {
+                              entities {
+                              ... on ApmApplicationEntityOutline {
+                                    name
+                                    apmSummary {
+                                    errorRate
+                                    webResponseTimeAverage
+                                    webThroughput
+                                    nonWebThroughput
+                                    nonWebResponseTimeAverage
+                                  }
+                               }
+                             }
+                          }
+                        }
+                      }
+                    } """
+
+    resp  = requests.post(url=self.graphql_base_url, headers=headers, data=graphQuery)
     if resp.json().get("errors"):
       print("Error getting newrelic entities:", resp.json())
       return
@@ -49,7 +71,20 @@ class NewrelicCollector(object):
     deploymentMetric = GaugeMetricFamily('newrelic_application_deployment',' newrelic application deployment', labels=["appname", "version"])
     
     timeInSeconds = 3600  # Get list of deployment which happened in last 1 hour
-    resp  = requests.post(url=self.graphql_base_url, headers=headers, data='{{actor{{nrql(query:"SELECT * FROM Deployment SINCE {0} seconds AGO "accounts:{1}){{nrql results}}}}}}'.format(timeInSeconds,self.account_number))
+
+    deploymentGraphQuery = """{{
+                                actor{{
+                                  nrql(
+                                    query: "SELECT * FROM Deployment SINCE {0} seconds AGO "
+                                    accounts: {1}
+                                  ) {{
+                                      nrql 
+                                      results
+                                      }}
+                                  }}
+                              }}"""
+    resp  = requests.post(url=self.graphql_base_url, headers=headers, data=deploymentGraphQuery.format(timeInSeconds,self.account_number))
+    
     if resp.json().get("errors"):
         print("Error getting newrelic deployment response : ", resp.json())
         return

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -20,7 +20,7 @@ class NewrelicCollector(object):
     metrics = {
         # add the metrics
         'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error rate', labels=["appname"]),
-        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_response_time','newrelic application web response time average', labels=["appname"]),
+        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_web_response_time','newrelic application web response time average', labels=["appname"]),
         'webThroughput': GaugeMetricFamily('newrelic_application_web_throughput','newrelic application web throughput', labels=["appname"]),
         'nonWebThroughput': GaugeMetricFamily('newrelic_application_nonweb_throughput','newrelic application non web throughput', labels=["appname"]),
         'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_application_nonweb_response_time','newrelic application non web response time average', labels=["appname"]),

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
+import json
 import time
 import requests
 import click
-import json
+import os
 
 from datetime import datetime, timedelta
 from prometheus_client import start_http_server
@@ -11,25 +12,21 @@ from prometheus_client.core import GaugeMetricFamily, REGISTRY
 
 
 class NewrelicCollector(object):
-  def __init__(self, apikey):
+  def __init__(self, apikey, account_number):
     self.graphql_base_url = "https://api.newrelic.com/graphql"
     self.api_key = apikey
+    self.account_number = account_number
 
   def collect(self):
     print("Collecting\n")
     
     # The metrics we want to export.
     metrics = {
+        # add the metrics for apdex_target
         'apdexScore': GaugeMetricFamily('newrelic_application_apdex_score',' newrelic application apdex_score', labels=["appname"]),
         'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error_rate', labels=["appname"]),
-        'hostCount': GaugeMetricFamily('newrelic_application_host_count','newrelic application host count', labels=["appname"]),
-        'instanceCount': GaugeMetricFamily('newrelic_applicaiton_instance_count','newrelic application instance count', labels=["appname"]),
-        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_application_non_web_response_time_average','newrelica applicationnon web response time average',labels=["appname"]),
-        'nonWebThroughput': GaugeMetricFamily('newrelic_application_non_web_throughput','newrelic applicationn on web throughput', labels=["appname"]),
-        'responseTimeAverage': GaugeMetricFamily('newrelic_application_response_time',' newrelic application response in sec', labels=["appname"]),
-        'throughput': GaugeMetricFamily('newrelic_application_throughput',' newrelic application throughput',labels=["appname"]),
-        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_web_response_time_average','newrelic_application web response time average', labels=["appname"]),
-        'webThroughput': GaugeMetricFamily('newrelic_application_web_throughput','newrelic application web throughput', labels=["appname"]),
+        'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_response_time','newrelic_application web response time average', labels=["appname"]),
+        'webThroughput': GaugeMetricFamily('newrelic_application_throughput','newrelic application web throughput', labels=["appname"]),
     }
 
     # Get all entity Guids
@@ -38,56 +35,51 @@ class NewrelicCollector(object):
     if resp.json().get("errors"):
       print("Error getting newrelic entities:", resp.json())
       return
-    
-    guidDict = {}
-    # saving guid and name in dictionary (guidDict)
-    for entity in resp.json().get("data").get("actor").get("entitySearch").get("results").get("entities"):
-      guidDict[entity["guid"]] = entity["name"]
-
     # Pass the metrics to the prometheus by looping through entity
     for metric in metrics:
       for entity in  resp.json().get("data").get("actor").get("entitySearch").get("results").get("entities"):
         if entity.get("apmSummary"):
           try:
-            metrics[metric].add_metric([entity["name"]], entity.get("apmSummary")[metric])
+            metric_value = entity.get("apmSummary")[metric]
+            if metric == 'webResponseTimeAverage':
+              # Currently apdex_score is in seconds format 
+              # convert apdex_score from seconds to miliseconds
+              metric_value = metric_value * 1000
+            metrics[metric].add_metric([entity["name"]], metric_value)
           except KeyError:
             pass
       yield metrics[metric]
 
-    # We can pass only 25 Guids in one request, so dividing all guids in chunks of 25,
-    # and fetching deployments for those 25 guids
-    # Get list of deployment which happened in last 1 hour
-    t = datetime.today()-timedelta(hours=1)
-    deploymentArray = []
-    guids = list(guidDict.keys())
     
-    chunk_size = 25
-    for i in range(0, len(guids), chunk_size):      
-      resp  = requests.post(url=self.graphql_base_url, headers=headers, data='{{actor {{entities(guids: {0}) {{deploymentSearch(filter: {{timeWindow: {{startTime: {1} }}}}) {{results {{version timestamp entityGuid}}}}}}}}}}'.format(json.dumps(guids[i:i+chunk_size]),round(t.timestamp()*1000)))
+    # Get list of deployment which happened in last 1 hour
+    # Fetch the account number from the environment variable
+    deploymentArray = []
+    newrelic_account_number = int(self.account_number)
+    resp  = requests.post(url=self.graphql_base_url, headers=headers, data='{{actor{{nrql(query:"SELECT * FROM Deployment SINCE 3600 seconds AGO "accounts:{0}){{nrql results}}}}}}'.format(json.dumps(newrelic_account_number)))
+    
+    # Iterate through the deployment results and extract relevant information
+    for deployments in resp.json().get("data").get("actor").get("nrql").get("results"):
       if resp.json().get("errors"):
         print("Error getting newrelic deployments:", resp.json())
         return
-
-      for entity in resp.json().get("data").get("actor").get("entities"):        
-        for deployments in entity.get("deploymentSearch").get("results"):          
-          deploymentArray.append({
-            "name": guidDict.get(deployments.get("entityGuid")),
-            "timestamp": deployments.get("timestamp"),
-            "version": deployments.get("version")
-          })
-        
-    print(deploymentArray)
-    # Expose deployment metric
+      deploymentArray.append({
+        "name": deployments.get("entity.name"),
+        "timestamp": deployments.get("timestamp"),
+        "version": deployments.get("version")
+      })
+    
     deploymentMetric = GaugeMetricFamily('newrelic_application_deployment',' newrelic application deployment', labels=["appname", "version"])
     for deployment in deploymentArray:
       # Passing timestamp as seconds because prometheus client automatically converts timestamp to milliseconds
       deploymentMetric.add_metric([deployment['name'], deployment['version']], 1, int(deployment['timestamp']/1000))
     yield deploymentMetric
-
+    
 @click.command()
 @click.option('--api-key', '-a', envvar='APIKEY', help='API key for newrelic', required=True)
-def main(api_key):
-  REGISTRY.register(NewrelicCollector(api_key))
+@click.option('--account-number','-n',envvar='NEWRELIC_ACCOUNT_NUMBER', help='Account Number for newrelic',required=True)
+def main(api_key, account_number):   
+  collector = NewrelicCollector(api_key, account_number)
+  REGISTRY.register(collector)
   start_http_server(9126)
   while True: 
     time.sleep(1)

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -22,8 +22,8 @@ class NewrelicCollector(object):
         'errorRate': GaugeMetricFamily('newrelic_application_error_rate',' newrelic application error rate', labels=["appname"]),
         'webResponseTimeAverage': GaugeMetricFamily('newrelic_application_response_time','newrelic application web response time average', labels=["appname"]),
         'webThroughput': GaugeMetricFamily('newrelic_application_web_throughput','newrelic application web throughput', labels=["appname"]),
-        'nonWebThroughput': GaugeMetricFamily('newrelic_nonweb_throughput','newrelic application non web throughput', labels=["appname"]),
-        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_nonweb_response_time','newrelic application non web response time average', labels=["appname"]),
+        'nonWebThroughput': GaugeMetricFamily('newrelic_application_nonweb_throughput','newrelic application non web throughput', labels=["appname"]),
+        'nonWebResponseTimeAverage': GaugeMetricFamily('newrelic_application_nonweb_response_time','newrelic application non web response time average', labels=["appname"]),
    }
 
     headers = {'API-Key': self.api_key}

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -57,7 +57,7 @@ class NewrelicCollector(object):
     # Iterate through the deployment result and adding relevant information to depoymentMetric
     for deployments in resp.json().get("data").get("actor").get("nrql").get("results"):
       # Passing timestamp as seconds because prometheus client automatically converts timestamp to milliseconds
-      deploymentMetric.add_metric([deployments.get("entity.name"),deployments.get("version")], int(deployments.get("timestamp") / 1000))
+      deploymentMetric.add_metric([deployments.get("entity.name"),deployments.get("version")],1, int(deployments.get("timestamp") / 1000))
     yield deploymentMetric
     
     
@@ -67,7 +67,7 @@ class NewrelicCollector(object):
 def main(api_key, account_number):   
   collector = NewrelicCollector(api_key, account_number)
   REGISTRY.register(collector)
-  start_http_server(9126)
+  start_http_server(9127)
   while True: 
     time.sleep(1)
     

--- a/newrelic_exporter.py
+++ b/newrelic_exporter.py
@@ -67,7 +67,7 @@ class NewrelicCollector(object):
 def main(api_key, account_number):   
   collector = NewrelicCollector(api_key, account_number)
   REGISTRY.register(collector)
-  start_http_server(9127)
+  start_http_server(9126)
   while True: 
     time.sleep(1)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prometheus-client==0.7.0
-requests==2.22
-click==7.0
+prometheus-client==0.17.1
+requests==2.31.0
+click==8.1.7


### PR DESCRIPTION
[DEVOPS-3289](https://ridecell.atlassian.net/browse/DEVOPS-3289) Using GraphQL API for exporting new-relic metrics to prometheus

[DEVOPS-3289]: https://ridecell.atlassian.net/browse/DEVOPS-3289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ